### PR TITLE
Fixed logical conditions in webrtc_page.dart

### DIFF
--- a/lib/presentation/pages/webrtc/webrtc_page.dart
+++ b/lib/presentation/pages/webrtc/webrtc_page.dart
@@ -52,10 +52,10 @@ class _WebrtcPageState extends State<WebrtcPage> {
           _remoteRenderer.initialize();
           _textEditingController.text = '';
         } else {
-          if (state.localStream != null || _localRenderer.srcObject != state.localStream) {
+          if (state.localStream != null && _localRenderer.srcObject != state.localStream) {
             _localRenderer.srcObject = state.localStream!;
           }
-          if (state.remoteStream != null || _remoteRenderer.srcObject != state.remoteStream) {
+          if (state.remoteStream != null && _remoteRenderer.srcObject != state.remoteStream) {
             _remoteRenderer.srcObject = state.remoteStream!;
           }
           if (state.roomId != null && state.roomId != _textEditingController.text) {


### PR DESCRIPTION
This commit addresses an issue in the webrtc_page.dart, resulting in `Unhandled Exception: Null check operator used on a null value`, since the logical conditions for updating the local and remote streams were mistakenly using the 'or' (||) instead of the 'and' (&&) operator. This fix ensures that stream updates only occur when both conditions are met: the stream is not null, and the current stream source is different from the new stream.
